### PR TITLE
Use realpath to resolve symlinks back to the underlying device.

### DIFF
--- a/lib/BlockStorageTest.php
+++ b/lib/BlockStorageTest.php
@@ -1006,7 +1006,7 @@ abstract class BlockStorageTest {
     }
     if ($device && $removeNumericSuffix && preg_match('/[a-z]([0-9]+)$/', $device, $m)) $device = substr($device, 0, strlen($m[1])*-1);
     
-    return $device;
+    return realpath($device);
   }
   
   /**


### PR DESCRIPTION
This fixes block devices with device-mapper layered over it.
Corrects issue #6.